### PR TITLE
Set package ecosystem to 'npm' in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request introduces a new configuration file to enable automated dependency updates using Dependabot. This will help keep the project's npm dependencies up to date on a weekly schedule.

Dependency management improvements:

* Added a `.github/dependabot.yml` configuration file to enable weekly npm dependency updates via Dependabot.