### PR TITLE
Add Dependabot grouping for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,37 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+    groups:
+      next:
+        patterns:
+          - next
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+      testing:
+        patterns:
+          - jest
+          - jest-environment-jsdom
+          - "@jest/*"
+          - "@testing-library/*"
+      tailwind:
+        patterns:
+          - tailwindcss
+          - "@tailwindcss/*"
+      typescript:
+        patterns:
+          - typescript
+          - "@types/node"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `groups` to the existing Dependabot config so related updates are batched into single PRs rather than one PR per package.

**npm groups:**
| Group | Packages |
|---|---|
| `next` | next, react, react-dom, @types/react, @types/react-dom |
| `testing` | jest, jest-environment-jsdom, @jest/*, @testing-library/* |
| `tailwind` | tailwindcss, @tailwindcss/* |
| `typescript` | typescript, @types/node |

**GitHub Actions:** all actions bundled into one PR per update cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)