### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for everything
+* @j-sm-n
+
+# Policy content and funding data require editorial review
+/content/ @j-sm-n
+/data/ @j-sm-n
+
+# CI and dependency config
+/.github/ @j-sm-n


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` to route review requests automatically.

- `*` — @j-sm-n owns everything by default
- `/content/` and `/data/` — explicit entries so policy and funding changes always require editorial sign-off
- `/.github/` — ensures CI and dependency config changes get reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)