### PR TITLE
Wire up bidirectional entity links with resolved titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## What does this PR do?
+
+<!-- One paragraph: what changed and why. Link to a GitHub Issue if one exists. -->
+
+## Type of change
+
+- [ ] New content (policy, organization, or funder entry)
+- [ ] Bug fix
+- [ ] New feature / enhancement
+- [ ] Refactor (no behavior change)
+- [ ] Docs / config only
+
+## Content checklist (for policy/org/funder entries)
+
+- [ ] All frontmatter fields are present and match the schema in CLAUDE.md
+- [ ] Every factual claim cites a primary source (FEC, OpenSecrets, or direct reporting)
+- [ ] Tone is neutral and factual — no advocacy language
+- [ ] Plain-language summary is understandable without domain knowledge
+- [ ] `funding_confidence` reflects what the source actually establishes
+
+## Code checklist (for code changes)
+
+- [ ] Tests written before implementation (TDD)
+- [ ] All new functions have tests; all tests pass (`npm test`)
+- [ ] No TypeScript errors (`npm run build`)
+- [ ] MDX components degrade gracefully without JS
+
+## Screenshots / previews
+
+<!-- For UI changes, paste a screenshot or describe what to look for. -->
+
+## Anything reviewers should pay special attention to?
+
+<!-- Optional: highlight tricky decisions, open questions, or areas of uncertainty. -->

--- a/src/app/funders/[slug]/page.tsx
+++ b/src/app/funders/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { getAllFunderSlugs, getFunder } from "@/lib/funders";
+import { getAllFunderSlugs, getFunder, getRelatedFunders } from "@/lib/funders";
+import { getRelatedOrgs } from "@/lib/organizations";
+import { getRelatedPolicies } from "@/lib/policies";
 import type { Metadata } from "next";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -45,6 +47,8 @@ export default async function FunderPage({
   if (!funder) notFound();
 
   const { frontmatter, content } = funder;
+  const relatedOrgs = getRelatedOrgs(frontmatter.related_orgs);
+  const relatedPolicies = getRelatedPolicies(frontmatter.related_policies);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -68,34 +72,34 @@ export default async function FunderPage({
             )}
           </dl>
 
-          {frontmatter.related_orgs.length > 0 && (
+          {relatedOrgs.length > 0 && (
             <div className="mt-4">
               <p className="text-sm font-medium text-gray-700 mb-1">Organizations backed</p>
               <div className="flex flex-wrap gap-2">
-                {frontmatter.related_orgs.map((orgSlug) => (
+                {relatedOrgs.map((o) => (
                   <Link
-                    key={orgSlug}
-                    href={`/organizations/${orgSlug}`}
+                    key={o.slug}
+                    href={`/organizations/${o.slug}`}
                     className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
                   >
-                    {orgSlug}
+                    {o.title}
                   </Link>
                 ))}
               </div>
             </div>
           )}
 
-          {frontmatter.related_policies.length > 0 && (
+          {relatedPolicies.length > 0 && (
             <div className="mt-3">
               <p className="text-sm font-medium text-gray-700 mb-1">Related policies</p>
               <div className="flex flex-wrap gap-2">
-                {frontmatter.related_policies.map((policySlug) => (
+                {relatedPolicies.map((p) => (
                   <Link
-                    key={policySlug}
-                    href={`/policies/${policySlug}`}
+                    key={p.slug}
+                    href={`/policies/${p.slug}`}
                     className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-700 hover:bg-blue-100"
                   >
-                    {policySlug}
+                    {p.title}
                   </Link>
                 ))}
               </div>

--- a/src/app/funders/[slug]/page.tsx
+++ b/src/app/funders/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { getAllFunderSlugs, getFunder, getRelatedFunders } from "@/lib/funders";
+import { getAllFunderSlugs, getFunder } from "@/lib/funders";
 import { getRelatedOrgs } from "@/lib/organizations";
 import { getRelatedPolicies } from "@/lib/policies";
 import type { Metadata } from "next";

--- a/src/app/organizations/[slug]/page.tsx
+++ b/src/app/organizations/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { getAllOrgSlugs, getOrg } from "@/lib/organizations";
+import { getAllOrgSlugs, getOrg, getRelatedOrgs } from "@/lib/organizations";
+import { getRelatedFunders } from "@/lib/funders";
+import { getRelatedPolicies } from "@/lib/policies";
 import type { Metadata } from "next";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -39,6 +41,11 @@ export default async function OrgPage({
   if (!org) notFound();
 
   const { frontmatter, content } = org;
+  const relatedFunders = getRelatedFunders(frontmatter.related_funders);
+  const relatedPolicies = getRelatedPolicies(frontmatter.related_policies);
+  const relatedOrgs = frontmatter.parent_org
+    ? getRelatedOrgs([frontmatter.parent_org])
+    : [];
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -72,34 +79,51 @@ export default async function OrgPage({
             </div>
           </dl>
 
-          {frontmatter.related_funders.length > 0 && (
+          {relatedOrgs.length > 0 && (
             <div className="mt-4">
-              <p className="text-sm font-medium text-gray-700 mb-1">Known funders</p>
+              <p className="text-sm font-medium text-gray-700 mb-1">Parent organization</p>
               <div className="flex flex-wrap gap-2">
-                {frontmatter.related_funders.map((slug) => (
+                {relatedOrgs.map((o) => (
                   <Link
-                    key={slug}
-                    href={`/funders/${slug}`}
+                    key={o.slug}
+                    href={`/organizations/${o.slug}`}
                     className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
                   >
-                    {slug}
+                    {o.title}
                   </Link>
                 ))}
               </div>
             </div>
           )}
 
-          {frontmatter.related_policies.length > 0 && (
+          {relatedFunders.length > 0 && (
+            <div className="mt-4">
+              <p className="text-sm font-medium text-gray-700 mb-1">Known funders</p>
+              <div className="flex flex-wrap gap-2">
+                {relatedFunders.map((f) => (
+                  <Link
+                    key={f.slug}
+                    href={`/funders/${f.slug}`}
+                    className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
+                  >
+                    {f.title}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {relatedPolicies.length > 0 && (
             <div className="mt-3">
               <p className="text-sm font-medium text-gray-700 mb-1">Related policies</p>
               <div className="flex flex-wrap gap-2">
-                {frontmatter.related_policies.map((slug) => (
+                {relatedPolicies.map((p) => (
                   <Link
-                    key={slug}
-                    href={`/policies/${slug}`}
+                    key={p.slug}
+                    href={`/policies/${p.slug}`}
                     className="rounded bg-blue-50 px-2 py-0.5 text-xs text-blue-700 hover:bg-blue-100"
                   >
-                    {slug}
+                    {p.title}
                   </Link>
                 ))}
               </div>

--- a/src/app/policies/[slug]/page.tsx
+++ b/src/app/policies/[slug]/page.tsx
@@ -5,7 +5,10 @@ import {
   getAllPolicySlugs,
   getPolicy,
   getFundingData,
+  getRelatedPolicies,
 } from "@/lib/policies";
+import { getRelatedOrgs } from "@/lib/organizations";
+import { getRelatedFunders } from "@/lib/funders";
 import FundingBreakdown from "@/components/FundingBreakdown";
 import DonorMap from "@/components/DonorMap";
 import type { Metadata } from "next";
@@ -38,6 +41,8 @@ export default async function PolicyPage({
   if (!policy) notFound();
 
   const funding = getFundingData(policy.frontmatter.funding_data);
+  const relatedOrgs = getRelatedOrgs(policy.frontmatter.related_orgs);
+  const relatedFunders = getRelatedFunders(policy.frontmatter.related_funders);
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-12">
@@ -84,6 +89,46 @@ export default async function PolicyPage({
         <div className="prose prose-gray max-w-none">
           <MDXRemote source={policy.content} />
         </div>
+
+        {(relatedOrgs.length > 0 || relatedFunders.length > 0) && (
+          <section className="mt-10 border-t border-gray-200 pt-8">
+            <h2 className="text-xl font-bold text-gray-900 mb-4">
+              Who&apos;s behind this
+            </h2>
+            {relatedOrgs.length > 0 && (
+              <div className="mb-4">
+                <p className="text-sm font-medium text-gray-700 mb-2">Organizations</p>
+                <div className="flex flex-wrap gap-2">
+                  {relatedOrgs.map((o) => (
+                    <Link
+                      key={o.slug}
+                      href={`/organizations/${o.slug}`}
+                      className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
+                    >
+                      {o.title}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+            {relatedFunders.length > 0 && (
+              <div>
+                <p className="text-sm font-medium text-gray-700 mb-2">Key funders</p>
+                <div className="flex flex-wrap gap-2">
+                  {relatedFunders.map((f) => (
+                    <Link
+                      key={f.slug}
+                      href={`/funders/${f.slug}`}
+                      className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200"
+                    >
+                      {f.title}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
 
         <section className="mt-12 border-t border-gray-200 pt-8">
           <h2 className="text-xl font-bold text-gray-900 mb-6">

--- a/src/app/policies/[slug]/page.tsx
+++ b/src/app/policies/[slug]/page.tsx
@@ -5,7 +5,6 @@ import {
   getAllPolicySlugs,
   getPolicy,
   getFundingData,
-  getRelatedPolicies,
 } from "@/lib/policies";
 import { getRelatedOrgs } from "@/lib/organizations";
 import { getRelatedFunders } from "@/lib/funders";

--- a/src/components/PolicyCard.test.tsx
+++ b/src/components/PolicyCard.test.tsx
@@ -12,6 +12,8 @@ const base: PolicyFrontmatter = {
   summary: "Requires independent audits for high-risk AI systems.",
   tags: ["AI", "regulation"],
   funding_data: "ai-accountability-act",
+  related_orgs: [],
+  related_funders: [],
 };
 
 describe("PolicyCard", () => {

--- a/src/lib/funders.test.ts
+++ b/src/lib/funders.test.ts
@@ -1,0 +1,142 @@
+import { jest, afterEach, describe, it, expect } from "@jest/globals";
+import fs from "fs";
+import {
+  getAllFunderSlugs,
+  getFunder,
+  getAllFunders,
+  getRelatedFunders,
+} from "./funders";
+
+const mockFiles = (files: string[]) =>
+  files as unknown as ReturnType<typeof fs.readdirSync>;
+
+function makeFunderMdx(slug: string, title = "Test Funder", type = "individual") {
+  return `---
+title: "${title}"
+slug: "${slug}"
+type: "${type}"
+related_orgs: []
+related_policies: []
+confirmed_contributions: []
+sources: []
+---
+
+Content here.
+`;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("getAllFunderSlugs", () => {
+  it("returns slugs from .mdx files in the funders directory", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["greg-brockman.mdx", "joe-lonsdale.mdx", "README.md"]));
+
+    expect(getAllFunderSlugs()).toEqual(["greg-brockman", "joe-lonsdale"]);
+  });
+
+  it("filters out unsafe slugs", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["good-funder.mdx", "Bad Funder.mdx", "../evil.mdx"]));
+
+    expect(getAllFunderSlugs()).toEqual(["good-funder"]);
+  });
+
+  it("returns empty array if directory does not exist", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(getAllFunderSlugs()).toEqual([]);
+  });
+});
+
+describe("getFunder", () => {
+  it("parses frontmatter and content from an MDX file", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeFunderMdx("greg-brockman", "Greg Brockman"));
+
+    const funder = getFunder("greg-brockman");
+    expect(funder).not.toBeNull();
+    expect(funder!.frontmatter.title).toBe("Greg Brockman");
+    expect(funder!.frontmatter.type).toBe("individual");
+    expect(funder!.content.trim()).toBe("Content here.");
+  });
+
+  it("returns null if frontmatter slug does not match the filename slug", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeFunderMdx("different-slug"));
+
+    expect(getFunder("greg-brockman")).toBeNull();
+  });
+
+  it("returns null if the file does not exist", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(getFunder("missing-funder")).toBeNull();
+  });
+
+  it("returns null for unsafe slug input", () => {
+    expect(getFunder("../etc/passwd")).toBeNull();
+  });
+
+  it("returns null for an invalid funder type", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      makeFunderMdx("bad-type-funder", "Bad Type Funder", "invalid-type")
+    );
+    expect(getFunder("bad-type-funder")).toBeNull();
+  });
+});
+
+describe("getAllFunders", () => {
+  it("returns funders sorted alphabetically by title", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["zara-investor.mdx", "alpha-funder.mdx"]));
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: unknown) => {
+      if ((p as string).includes("zara-investor"))
+        return makeFunderMdx("zara-investor", "Zara Investor");
+      return makeFunderMdx("alpha-funder", "Alpha Funder");
+    });
+
+    const funders = getAllFunders();
+    expect(funders[0].frontmatter.title).toBe("Alpha Funder");
+    expect(funders[1].frontmatter.title).toBe("Zara Investor");
+  });
+});
+
+describe("getRelatedFunders", () => {
+  it("returns slug and title for each valid slug", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: unknown) => {
+      if ((p as string).includes("greg-brockman"))
+        return makeFunderMdx("greg-brockman", "Greg Brockman");
+      return makeFunderMdx("joe-lonsdale", "Joe Lonsdale");
+    });
+
+    const result = getRelatedFunders(["greg-brockman", "joe-lonsdale"]);
+    expect(result).toEqual([
+      { slug: "greg-brockman", title: "Greg Brockman" },
+      { slug: "joe-lonsdale", title: "Joe Lonsdale" },
+    ]);
+  });
+
+  it("silently drops slugs that do not resolve to a real funder", () => {
+    jest.spyOn(fs, "existsSync").mockImplementation((p: unknown) =>
+      (p as string).includes("real-funder")
+    );
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeFunderMdx("real-funder", "Real Funder"));
+
+    const result = getRelatedFunders(["real-funder", "ghost-funder"]);
+    expect(result).toEqual([{ slug: "real-funder", title: "Real Funder" }]);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = getRelatedFunders([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/funders.ts
+++ b/src/lib/funders.ts
@@ -124,3 +124,10 @@ export function getAllFunders(): Funder[] {
     .filter((f): f is Funder => f !== null)
     .sort((a, b) => a.frontmatter.title.localeCompare(b.frontmatter.title));
 }
+
+export function getRelatedFunders(slugs: string[]): { slug: string; title: string }[] {
+  return slugs
+    .map((slug) => getFunder(slug))
+    .filter((f): f is Funder => f !== null)
+    .map((f) => ({ slug: f.frontmatter.slug, title: f.frontmatter.title }));
+}

--- a/src/lib/organizations.test.ts
+++ b/src/lib/organizations.test.ts
@@ -1,0 +1,141 @@
+import { jest, afterEach, describe, it, expect } from "@jest/globals";
+import fs from "fs";
+import {
+  getAllOrgSlugs,
+  getOrg,
+  getAllOrgs,
+  getRelatedOrgs,
+} from "./organizations";
+
+const mockFiles = (files: string[]) =>
+  files as unknown as ReturnType<typeof fs.readdirSync>;
+
+function makeOrgMdx(slug: string, title = "Test Org", type = "super-pac") {
+  return `---
+title: "${title}"
+slug: "${slug}"
+type: "${type}"
+funding_confidence: "reported"
+related_policies: []
+related_funders: []
+sources: []
+---
+
+Content here.
+`;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("getAllOrgSlugs", () => {
+  it("returns slugs from .mdx files in the organizations directory", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["acme-pac.mdx", "dark-money-inc.mdx", "README.md"]));
+
+    expect(getAllOrgSlugs()).toEqual(["acme-pac", "dark-money-inc"]);
+  });
+
+  it("filters out unsafe slugs", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["good-org.mdx", "Bad Org.mdx", "../evil.mdx"]));
+
+    expect(getAllOrgSlugs()).toEqual(["good-org"]);
+  });
+
+  it("returns empty array if directory does not exist", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(getAllOrgSlugs()).toEqual([]);
+  });
+});
+
+describe("getOrg", () => {
+  it("parses frontmatter and content from an MDX file", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeOrgMdx("leading-the-future", "Leading the Future"));
+
+    const org = getOrg("leading-the-future");
+    expect(org).not.toBeNull();
+    expect(org!.frontmatter.title).toBe("Leading the Future");
+    expect(org!.frontmatter.type).toBe("super-pac");
+    expect(org!.content.trim()).toBe("Content here.");
+  });
+
+  it("returns null if frontmatter slug does not match the filename slug", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeOrgMdx("different-slug"));
+
+    expect(getOrg("leading-the-future")).toBeNull();
+  });
+
+  it("returns null if the file does not exist", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(getOrg("missing-org")).toBeNull();
+  });
+
+  it("returns null for unsafe slug input", () => {
+    expect(getOrg("../etc/passwd")).toBeNull();
+  });
+
+  it("returns null for an invalid org type", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      makeOrgMdx("bad-type-org", "Bad Type Org", "invalid-type")
+    );
+    expect(getOrg("bad-type-org")).toBeNull();
+  });
+});
+
+describe("getAllOrgs", () => {
+  it("returns orgs sorted alphabetically by title", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest
+      .spyOn(fs, "readdirSync")
+      .mockReturnValue(mockFiles(["zebra-pac.mdx", "alpha-org.mdx"]));
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: unknown) => {
+      if ((p as string).includes("zebra-pac")) return makeOrgMdx("zebra-pac", "Zebra PAC");
+      return makeOrgMdx("alpha-org", "Alpha Org");
+    });
+
+    const orgs = getAllOrgs();
+    expect(orgs[0].frontmatter.title).toBe("Alpha Org");
+    expect(orgs[1].frontmatter.title).toBe("Zebra PAC");
+  });
+});
+
+describe("getRelatedOrgs", () => {
+  it("returns slug and title for each valid slug", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: unknown) => {
+      if ((p as string).includes("leading-the-future"))
+        return makeOrgMdx("leading-the-future", "Leading the Future");
+      return makeOrgMdx("build-american-ai", "Build American AI");
+    });
+
+    const result = getRelatedOrgs(["leading-the-future", "build-american-ai"]);
+    expect(result).toEqual([
+      { slug: "leading-the-future", title: "Leading the Future" },
+      { slug: "build-american-ai", title: "Build American AI" },
+    ]);
+  });
+
+  it("silently drops slugs that do not resolve to a real org", () => {
+    jest.spyOn(fs, "existsSync").mockImplementation((p: unknown) =>
+      (p as string).includes("real-org")
+    );
+    jest.spyOn(fs, "readFileSync").mockReturnValue(makeOrgMdx("real-org", "Real Org"));
+
+    const result = getRelatedOrgs(["real-org", "ghost-org"]);
+    expect(result).toEqual([{ slug: "real-org", title: "Real Org" }]);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = getRelatedOrgs([]);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/organizations.ts
+++ b/src/lib/organizations.ts
@@ -116,3 +116,10 @@ export function getAllOrgs(): Organization[] {
     .filter((o): o is Organization => o !== null)
     .sort((a, b) => a.frontmatter.title.localeCompare(b.frontmatter.title));
 }
+
+export function getRelatedOrgs(slugs: string[]): { slug: string; title: string }[] {
+  return slugs
+    .map((slug) => getOrg(slug))
+    .filter((o): o is Organization => o !== null)
+    .map((o) => ({ slug: o.frontmatter.slug, title: o.frontmatter.title }));
+}

--- a/src/lib/policies.test.ts
+++ b/src/lib/policies.test.ts
@@ -5,6 +5,7 @@ import {
   getPolicy,
   getAllPolicies,
   getFundingData,
+  getRelatedPolicies,
 } from "./policies";
 
 // readdirSync has complex overloads; this cast lets mock return a plain string[]
@@ -222,5 +223,39 @@ describe("getFundingData", () => {
   it("returns null if the funding file does not exist", () => {
     jest.spyOn(fs, "existsSync").mockReturnValue(false);
     expect(getFundingData("missing")).toBeNull();
+  });
+});
+
+describe("getRelatedPolicies", () => {
+  it("returns slug and title for each valid slug", () => {
+    jest.spyOn(fs, "existsSync").mockReturnValue(true);
+    jest.spyOn(fs, "readFileSync").mockImplementation((p: unknown) => {
+      if ((p as string).includes("ai-act"))
+        return makeMdx("ai-act").replace('title: "Test Policy"', 'title: "AI Act"');
+      return makeMdx("privacy-bill").replace('title: "Test Policy"', 'title: "Privacy Bill"');
+    });
+
+    const result = getRelatedPolicies(["ai-act", "privacy-bill"]);
+    expect(result).toEqual([
+      { slug: "ai-act", title: "AI Act" },
+      { slug: "privacy-bill", title: "Privacy Bill" },
+    ]);
+  });
+
+  it("silently drops slugs that do not resolve to a real policy", () => {
+    jest.spyOn(fs, "existsSync").mockImplementation((p: unknown) =>
+      (p as string).includes("real-policy")
+    );
+    jest.spyOn(fs, "readFileSync").mockReturnValue(
+      makeMdx("real-policy").replace('title: "Test Policy"', 'title: "Real Policy"')
+    );
+
+    const result = getRelatedPolicies(["real-policy", "ghost-policy"]);
+    expect(result).toEqual([{ slug: "real-policy", title: "Real Policy" }]);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = getRelatedPolicies([]);
+    expect(result).toEqual([]);
   });
 });

--- a/src/lib/policies.ts
+++ b/src/lib/policies.ts
@@ -183,6 +183,13 @@ export function getAllPolicies(): Policy[] {
     });
 }
 
+export function getRelatedPolicies(slugs: string[]): { slug: string; title: string }[] {
+  return slugs
+    .map((slug) => getPolicy(slug))
+    .filter((p): p is Policy => p !== null)
+    .map((p) => ({ slug: p.frontmatter.slug, title: p.frontmatter.title }));
+}
+
 export function getFundingData(slug: string): FundingData | null {
   if (!isSafeSlug(slug)) return null;
   const filePath = safeResolve(FUNDING_DIR, `${slug}.json`);


### PR DESCRIPTION
## What does this PR do?

Slug arrays on entity detail pages previously rendered raw slugs as link text (e.g. `greg-brockman` instead of "Greg Brockman"). This adds resolver functions to the lib layer and updates all three detail page types to show real names. Policy pages also gain a new "Who's behind this" section — they had `related_orgs` and `related_funders` in their frontmatter schema but never displayed them.

## Type of change

- [x] New feature / enhancement

## Code checklist

- [x] Tests written before implementation (TDD)
- [x] All new functions have tests; all tests pass (`npm test`)
- [x] No TypeScript errors (`npm run build`)
- [x] MDX components degrade gracefully without JS

## Changes

**New lib functions** (each resolves a slug array → `{ slug, title }[]`, silently dropping missing entities):
- `getRelatedOrgs` in `src/lib/organizations.ts`
- `getRelatedFunders` in `src/lib/funders.ts`
- `getRelatedPolicies` in `src/lib/policies.ts`

**New test files:**
- `src/lib/organizations.test.ts` — full coverage of org lib + `getRelatedOrgs`
- `src/lib/funders.test.ts` — full coverage of funder lib + `getRelatedFunders`
- `src/lib/policies.test.ts` — added `getRelatedPolicies` tests

**Page updates:**
- Org detail: shows resolved funder/policy names; also resolves `parent_org` if set
- Funder detail: shows resolved org/policy names
- Policy detail: new "Who's behind this" section with linked org and funder chips

**Also adds** `.github/PULL_REQUEST_TEMPLATE.md` for contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)