### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Test, lint, and build


### PR DESCRIPTION
Potential fix for [https://github.com/TechPolicyDecoded/decoder/security/code-scanning/2](https://github.com/TechPolicyDecoded/decoder/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` with least privilege.  
Best single fix without changing functionality: define workflow-level permissions:

- `contents: read`

This is sufficient for `actions/checkout` and typical CI read operations, and it applies to all jobs unless overridden.  
Edit location: immediately under the `on:` trigger block (before `jobs:`), or under the specific `ci` job. Workflow-level is simplest and keeps policy centralized.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
